### PR TITLE
[UPDATE] working on state and validation of form

### DIFF
--- a/client/src/pages/SignUp/Steps.js
+++ b/client/src/pages/SignUp/Steps.js
@@ -53,7 +53,6 @@ const Steps = () => {
 const ProgressBar = (props) => {
   const progressBarRef = useRef();
   const progressWrapRef = useRef();
-  const progressItem = useRef();
 
   // 추후 progress wrap 이용해서 전부 처리
   useEffect(() => {
@@ -75,6 +74,7 @@ const ProgressBar = (props) => {
     // progress_bar div도 포함되어 있으니 1을 빼야 하니 총 2를 뺌
     progressFunc(props.pageNum, progressWidth, progressCountImg - 2);
   }, [props.pageNum]);
+
   // 현재 width를 바탕으로 progress bar 작업
   const progressFunc = (pageNum, width, count) => {
     progressBarRef.current.style.transition = "0.4s ease-in-out";
@@ -83,16 +83,16 @@ const ProgressBar = (props) => {
   return (
     <div ref={progressWrapRef} className="progress_wrap">
       <div ref={progressBarRef} className="progress_bar"></div>
-      <p className="circle active" src={UserIcon} alt="icon">
+      <p className="step active" src={UserIcon} alt="icon">
         1
       </p>
-      <p className="circle" src={UserIcon} alt="icon">
+      <p className="step" src={UserIcon} alt="icon">
         2
       </p>
-      <p className="circle" src={UserIcon} alt="icon">
+      <p className="step" src={UserIcon} alt="icon">
         3
       </p>
-      <p className="circle" src={UserIcon} alt="icon">
+      <p className="step" src={UserIcon} alt="icon">
         4
       </p>
     </div>

--- a/client/src/pages/SignUp/component/UserInfo.js
+++ b/client/src/pages/SignUp/component/UserInfo.js
@@ -1,12 +1,11 @@
 /* eslint-disable */
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import * as yup from "yup";
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { PageContext } from "../context/PageContext";
 const UserInfo = () => {
-  const { pageNum, setPageNum, formData, setFormData } =
-    useContext(PageContext);
+  const { pageNum, setPageNum, formData, setFormData } = useContext(PageContext);
   // form의 각 요소 지정
   const schema = yup.object().shape({
     id: yup.string().required("아이디를 다시 입력해주세요."),
@@ -20,14 +19,11 @@ const UserInfo = () => {
       .oneOf([yup.ref("password"), null], "패스워드가 틀립니다.")
       .required("패스워드를 다시 입력해주세요."),
     email: yup.string().email().required("이메일을 다시 입력해주세요."),
-  });
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm({
+  }).required();
+  const { register ,handleSubmit, trigger, formState: { errors }, unregister} = useForm({
     resolver: yupResolver(schema),
   });
+  // 다음 버튼 클릭 시, formData에 각 입력값 전달
   const onSubmit = (data) => {
     const values = {
       id: data.id,
@@ -38,7 +34,30 @@ const UserInfo = () => {
     setFormData({ ...formData, ...values });
     setPageNum(pageNum + 1);
   };
-
+  // input value 관리를 위한 state
+  const [userInputValue, setUserInputValue] = useState({
+    id:"",
+    password:"",
+    confirmPassword:"",
+    email:""
+  });
+  // input name별 onChange 관리
+  const onChange = useCallback((e) => {
+    const {name, value}=e.target;
+    setUserInputValue({...userInputValue,[name]:value});
+  });
+  useEffect(() => {
+    // 이전 페이지로 갔다가 다시 다음을 누르는 경우, 이미 input의 각 항목이 register 되어 있어서
+    // 오류가 발생하여 unregister 적용
+    unregister(["id","password","confirmPassword","email"]);
+    // context로부터 저장된 input value 호출
+    setUserInputValue({...userInputValue,
+    id:formData.id,
+    password: formData.password,
+    confirmPassword: formData.confirmPassword,
+    email: formData.email
+    });
+  }, []);
   return (
     <div>
       <form class="userInfo_form" onSubmit={handleSubmit(onSubmit)}>
@@ -48,6 +67,8 @@ const UserInfo = () => {
             type="text"
             placeholder="아이디를 입력하세요."
             {...register("id")}
+            value={userInputValue.id}
+            onChange={onChange}
           />
           <p>{errors.id?.message}</p>
         </div>
@@ -57,6 +78,8 @@ const UserInfo = () => {
             type="password"
             placeholder="패스워드를 입력하세요."
             {...register("password")}
+            value={userInputValue.password}
+            onChange={onChange}
           />
           <p>{errors.password?.message}</p>
         </div>
@@ -66,6 +89,8 @@ const UserInfo = () => {
             type="password"
             placeholder="패스워드를 다시 입력하세요."
             {...register("confirmPassword")}
+            value={userInputValue.confirmPassword}
+            onChange={onChange}
           />
           <p>{errors.confirmPassword?.message}</p>
         </div>
@@ -75,11 +100,13 @@ const UserInfo = () => {
             type="text"
             placeholder="이메일을 입력하세요."
             {...register("email")}
+            value={userInputValue.email}
+            onChange={onChange}
           />
           <p>{errors.email?.message}</p>
         </div>
         <hr />
-        <input type="submit" value="다음" />
+        <input onClick={()=>{console.log(errors)}} type="submit" value="다음" />
       </form>
     </div>
   );

--- a/client/src/pages/SignUp/index.css
+++ b/client/src/pages/SignUp/index.css
@@ -112,25 +112,25 @@
   position: absolute;
   top: 50%;
   left: 0;
-  width: 100%;
   height: 5px;
   background-color: var(--color-point);
 }
 .progress_wrap figure {
   z-index: 9990;
 }
-.progress_wrap .circle {
+.progress_wrap .step {
   width: 30px;
   height: 30px;
   background-color: #ffffff;
-  line-height: 26px;
+  line-height: 22px;
   text-align: center;
+  border: 3px solid var(--color-lightgray);
   border-radius: 50%;
   z-index: 9997;
 }
-.progress_wrap .circle.active {
-  border: 3px solid var(--color-point);
-  transition: 0.4s ease-in-out;
+.progress_wrap .step.active {
+  border: 3px solid var(--color-main);
+  transition: 0.8s ease-in-out;
   background-color: var(--color-point);
   color: #ffffff;
 }

--- a/client/src/setup/config/FormRegex.js
+++ b/client/src/setup/config/FormRegex.js
@@ -1,0 +1,1 @@
+// export const validSignup


### PR DESCRIPTION
- 회원가입 페이지에서 입력 후, 다음 페이지로 갔다가 다시 이전페이지로 올 때 입력한 값을 유지
- useForm의 register 함수가 이전 페이지로 왔다가 다음을 누를 시 오류를 일으켜 useEffect로 랜더링 후에 input의 각 항목을 unregister 시켜줌
- Steps.js에서 progress bar의 각 스텝 클래스를 'circle'에서 'step'으로 변경
- yup으로 input의 타입은 검사가 되지만 한글, 영어 구분 등 정규화에 대한 부분이 없기에 setup/config 폴더에 form validation 부분을 FormRegex.js로 구성하고자 하기에 파일 생성