### PR TITLE
[FIX] Fixed user_account data backup code in Datainitializer

### DIFF
--- a/server/iam/src/main/java/com/lhsk/iam/domain/account/service/DataInitializer.java
+++ b/server/iam/src/main/java/com/lhsk/iam/domain/account/service/DataInitializer.java
@@ -59,7 +59,7 @@ public class DataInitializer {
         List<AccountApiVO> accountList = accountClient.getAccounts();
         accountApiMapper.insertAccounts(accountList);
         // 백업 데이터 재입력
-        accountApiMapper.insertBackupUserAccount(info);
+        if (info.size() > 0) accountApiMapper.insertBackupUserAccount(info);
         // 과거 거래내역 추가
         while (true) {
            log.info("page : "+page);


### PR DESCRIPTION
Datainitializer에서 user_account 테이블의 데이터 백업하려 할때 data가 없어도 insert를 시도하여 sql 구문 오류가 발생함
→ 백업할 데이터가 없을 때 insert를 진행하지 않도록 코드 수정