### PR TITLE
[ADD] : 거래내역 이전 및 입출내역보고서 완성

### DIFF
--- a/server/iam/src/main/java/com/lhsk/iam/domain/account/model/mapper/AccountMapper.java
+++ b/server/iam/src/main/java/com/lhsk/iam/domain/account/model/mapper/AccountMapper.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.apache.ibatis.annotations.Mapper;
 
 import com.lhsk.iam.domain.account.model.vo.AccountVO;
+import com.lhsk.iam.domain.account.model.vo.InoutApiVO;
 import com.lhsk.iam.domain.account.model.vo.InoutRequestVO;
 import com.lhsk.iam.domain.account.model.vo.InoutVO;
 
@@ -46,4 +47,10 @@ public interface AccountMapper {
 	// 은행 이름으로 은행코드 찾기
 	String findBankCdByBankNm(String bankNm);
 	
+	
+	// 거래내역 데이터 이전
+	List<InoutVO> copyInoutData();
+	void insertInoutPast(List<InoutVO> inoutList);
+	// 이전에 끝난 inout_today 테이블 리셋
+	void resetInoutToday();
 }

--- a/server/iam/src/main/java/com/lhsk/iam/domain/report/model/mapper/ReportMapper.java
+++ b/server/iam/src/main/java/com/lhsk/iam/domain/report/model/mapper/ReportMapper.java
@@ -30,10 +30,13 @@ public interface ReportMapper {
 	
 	// 입출내역보고서
 	// 입출금내역보고서 데이터 추출
-	public List<InoutReportVO> getInoutReportData(InoutReportRequestVO requestVO);
+	public List<InoutReportVO> getAdminInoutReportData(InoutReportRequestVO requestVO);
+	public List<InoutReportVO> getUserInoutReportData(InoutReportRequestVO requestVO);
 	// 거래내역중 가장 최신의 날짜 추출
-	public String getLastBalanceDate(String acctNo);
+	public String getLastBalanceDate(String acctNo, String date);
 	// 해당 날짜의 거래내역으로부터 잔액 추출
 	public BigDecimal getLastBalance(String acctNo, String date);
+	// 계좌번호로 현재 잔액 추출
+	public BigDecimal getBalByAcctNo(String acctNo);
 	
 }

--- a/server/iam/src/main/java/com/lhsk/iam/domain/report/model/vo/InoutReportRequestVO.java
+++ b/server/iam/src/main/java/com/lhsk/iam/domain/report/model/vo/InoutReportRequestVO.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @Setter
 @Getter
 public class InoutReportRequestVO {
+	private int userNo;
 	private String bankNm;		// 은행명
 	private String bankCd;		// 은행코드
 	private String acctNo;		// 계좌번호

--- a/server/iam/src/main/java/com/lhsk/iam/global/schedule/Scheduler.java
+++ b/server/iam/src/main/java/com/lhsk/iam/global/schedule/Scheduler.java
@@ -1,8 +1,14 @@
 package com.lhsk.iam.global.schedule;
 
+import java.util.List;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.lhsk.iam.domain.account.model.mapper.AccountApiMapper;
+import com.lhsk.iam.domain.account.model.mapper.AccountMapper;
+import com.lhsk.iam.domain.account.model.vo.InoutApiVO;
+import com.lhsk.iam.domain.account.model.vo.InoutVO;
 import com.lhsk.iam.domain.user.model.mapper.UserMapper;
 
 import lombok.RequiredArgsConstructor;
@@ -11,14 +17,38 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class Scheduler {
 	private final UserMapper userMapper;
+	private final AccountMapper accountMapper;
+	private final AccountApiMapper accountApiMapper;
 	
-	// 매일 0시 0분 0초에 새로운 집계대상을 추가
+	// 매일 0시 0분 0초에 정해진 로직을 실행
 	@Scheduled(cron = "0 0 0 * * ?")
 	public void insertMenuClick() {
+		// 새로운 날짜의 메뉴 클릭 기록 대상을 DB에 insert
+		addMenuClickDB();
+		// 거래내역 데이터 복사 및 리셋
+		copyInoutData();
+	}
+	
+	public void addMenuClickDB() {
 		userMapper.insertMenuClick("all_account");
 		userMapper.insertMenuClick("inout");
 		userMapper.insertMenuClick("inout_report");
 		userMapper.insertMenuClick("daily_report");
 		userMapper.insertMenuClick("dashboard");
+		
 	}
+	
+	/* 
+	 * inout_today의 데이터를 복사해서 inout_past로 이동후 inout_today 비워주기
+	 * 복사와 리셋시, 거래날짜가 어제인 경우에만 실행(0시 0분 0초가 되었다는 것은 날짜가 바뀌었다는 뜻)
+	 * 이는 0시 0분 0초에 거래가 발생했을 경우 거래내역이 잘못 복사되거나 의도치않게 삭제되는 것을 방지하기 위함
+	 */
+	public void copyInoutData() {
+		List<InoutVO> inoutList = accountMapper.copyInoutData();
+		if(inoutList != null && inoutList.size() != 0) {
+			accountMapper.insertInoutPast(inoutList);
+		}
+		accountMapper.resetInoutToday();
+	}
+	
 }

--- a/server/iam/src/main/resources/mybatis/mapper/accountMapper.xml
+++ b/server/iam/src/main/resources/mybatis/mapper/accountMapper.xml
@@ -395,7 +395,7 @@
 		SELECT bank_nm FROM bank_code WHERE bank_cd=#{bankCd} 
 	</select>
 	
-    <select id="findBankCodeByBankName" resultType="String">
+    <select id="findBankCdByBankNm" resultType="String">
   		SELECT bank_cd FROM bank_code WHERE bank_nm = #{bankNm}
     </select>
 </mapper>

--- a/server/iam/src/main/resources/mybatis/mapper/accountMapper.xml
+++ b/server/iam/src/main/resources/mybatis/mapper/accountMapper.xml
@@ -398,4 +398,28 @@
     <select id="findBankCdByBankNm" resultType="String">
   		SELECT bank_cd FROM bank_code WHERE bank_nm = #{bankNm}
     </select>
+    
+    
+    <select id="copyInoutData" resultType="InoutVO">
+    	SELECT acct_no, bank_cd, inout_dv, trsc_dt, trsc_tm, bal, rmrk1, trsc_amt, curr_cd 
+		FROM inout_today 
+		WHERE DATE(trsc_dt) = DATE_SUB(CURDATE(), INTERVAL 1 DAY)
+    </select>
+    
+	<insert id="insertInoutPast" parameterType="java.util.ArrayList" useGeneratedKeys="true" keyProperty="trscNo">
+		INSERT INTO inout_past(acct_no, bank_cd, inout_dv, trsc_dt, trsc_tm, bal, rmrk1, trsc_amt, curr_cd) 
+		VALUES
+		<foreach collection="list" item="inout" separator=",">
+			(
+				#{inout.acctNo},#{inout.bankCd},#{inout.inoutDv},#{inout.trscDt}, 
+				#{inout.trscTm},#{inout.bal},#{inout.rmrk1},#{inout.trscAmt},#{inout.currCd}
+			)
+		</foreach>
+	</insert>
+	
+	<delete id="resetInoutToday">
+		DELETE FROM inout_today WHERE DATE(trsc_dt) = DATE_SUB(CURDATE(), INTERVAL 1 DAY)
+	</delete>
+	
+	
 </mapper>

--- a/server/iam/src/main/resources/mybatis/mapper/reportMapper.xml
+++ b/server/iam/src/main/resources/mybatis/mapper/reportMapper.xml
@@ -76,7 +76,7 @@
 	</select>
 	
 
-	<select id="getInoutReportData" resultType="InoutReportVO">
+	<select id="getAdminInoutReportData" resultType="InoutReportVO">
 	    SELECT b.bank_nm, a.acct_no,
 	           (SELECT bal FROM inout_past WHERE trsc_dt = #{startDt} AND acct_no = a.acct_no ORDER BY trsc_tm DESC LIMIT 1) AS before_bal,
 	           SUM(CASE WHEN t.inout_dv = 1 AND t.trsc_dt &gt;= #{startDt} AND t.trsc_dt &lt;= #{endDt} THEN 1 ELSE 0 END) AS in_cnt,
@@ -98,10 +98,34 @@
 	    ORDER BY a.bank_cd asc
 	</select>
 	
+	<select id="getUserInoutReportData" resultType="InoutReportVO">
+	    SELECT b.bank_nm, a.acct_no,
+	           (SELECT bal FROM inout_past WHERE trsc_dt = #{startDt} AND acct_no = a.acct_no ORDER BY trsc_tm DESC LIMIT 1) AS before_bal,
+	           SUM(CASE WHEN t.inout_dv = 1 AND t.trsc_dt &gt;= #{startDt} AND t.trsc_dt &lt;= #{endDt} THEN 1 ELSE 0 END) AS in_cnt,
+	           SUM(CASE WHEN t.inout_dv = 1 AND t.trsc_dt &gt;= #{startDt} AND t.trsc_dt &lt;= #{endDt} THEN t.trsc_amt ELSE 0 END) AS in_sum,
+	           SUM(CASE WHEN t.inout_dv = 2 AND t.trsc_dt &gt;= #{startDt} AND t.trsc_dt &lt;= #{endDt} THEN 1 ELSE 0 END) AS out_cnt,
+	           SUM(CASE WHEN t.inout_dv = 2 AND t.trsc_dt &gt;= #{startDt} AND t.trsc_dt &lt;= #{endDt} THEN t.trsc_amt ELSE 0 END) AS out_sum,
+	           (SELECT bal FROM inout_past WHERE trsc_dt = #{endDt} AND acct_no = a.acct_no ORDER BY trsc_tm DESC LIMIT 1) AS after_bal
+	    FROM account a
+	    JOIN bank_code b ON a.bank_cd = b.bank_cd
+	    JOIN user_account ua ON a.acct_no = ua.acct_no
+	    LEFT JOIN inout_past t ON a.acct_no = t.acct_no
+	    WHERE 1=1
+	    <if test="bankCd != null and bankCd != 'null'">
+	        AND a.bank_cd = #{bankCd}
+	    </if>
+	    <if test="acctNo != null and acctNo != 'null'">
+	        AND a.acct_no = #{acctNo}
+	    </if>
+	    AND ua.user_no = #{userNo}
+	    GROUP BY b.bank_nm, a.acct_no
+	    ORDER BY a.bank_cd asc
+	</select>
+	
 	<select id="getLastBalanceDate" resultType="string">
         SELECT MAX(trsc_dt)
         FROM inout_past
-        WHERE acct_no = #{acctNo}
+        WHERE acct_no = #{acctNo} AND trsc_dt &lt; #{date}
     </select>
     
 	<select id="getLastBalance" resultType="java.math.BigDecimal">
@@ -111,9 +135,11 @@
 	    ORDER BY trsc_tm DESC
 	    LIMIT 1
 	</select>
+	
+	<select id="getBalByAcctNo" parameterType="String" resultType="java.math.BigDecimal">
+		SELECT bal FROM account WHERE acct_no = #{acctNo}
+	</select>
     
-    <select id="findBankCdByBankNm" resultType="String">
-    	SELECT bank_cd FROM bank_code WHERE bank_nm = #{bankNm}
-    </select>
+
 	
 </mapper>


### PR DESCRIPTION
1. 매일 0시 0분 0초마다 today테이블의 데이터를 past로 이전후 today를 리셋
 1-1. 0시 0분 0초에 거래내역이 발생할 수 있는 가능성을 고려하여, 거래날짜가 어제인 것만을 이전 및 삭제하도록 조건을 걸었음
2. 입출내역보고서 완성
 2-1. 일반사용자와 매니저 이상급인 경우로 따로 나누어 처리.
 2-2. 요청 JSON은 API문서 확인바람